### PR TITLE
Permit compilation under Debian or Ubuntu R package (closes #1)

### DIFF
--- a/src/kent/Makefile.Rtwobitlib
+++ b/src/kent/Makefile.Rtwobitlib
@@ -17,7 +17,8 @@ CC       := $(shell ${R_HOME}/bin/R CMD config CC)
 AR       := $(shell ${R_HOME}/bin/R CMD config AR)
 RANLIB   := $(shell ${R_HOME}/bin/R CMD config RANLIB)
 CFLAGS   := $(shell ${R_HOME}/bin/R CMD config CFLAGS)
-CPPFLAGS := $(shell ${R_HOME}/bin/R CMD config CPPFLAGS)
+#CPPFLAGS := $(shell ${R_HOME}/bin/R CMD config CPPFLAGS)
+CPPFLAGS := $(shell ${R_HOME}/bin/R CMD config --cppflags)
 LDFLAGS  := $(shell ${R_HOME}/bin/R CMD config LDFLAGS)
 
 CFLAGS   += -fpic


### PR DESCRIPTION
In #1 I noted that compilation failed but pointed at the wrong file.  The guilty part, if there is in fact one, is in th file `src/kent/Makefile.Rtwobitlib` because I see

```sh
edd@rob:~/git/rtwobitlib(devel)$ R CMD config CPPFLAGS

edd@rob:~/git/rtwobitlib(devel)$ R CMD config --cppflags
-I/usr/share/R/include
edd@rob:~/git/rtwobitlib(devel)$ 
```

The package uses the former along with a hardwired `I${R_HOME}/include` which, as I wrote in #1, will not work here.  Switching to the alternate `--cppflags` works (see below).  We may have to discuss with R Core if 'CPPFLAGS' should return what `--cppflags` returns.  Until then the PR here may help.

<details>

I changed to version in `DESCRIPTION` to create a diifferently name tar.gz to be plainer:

```
edd@rob:~/git/rtwobitlib(devel)$ docker run --rm -ti -v $PWD:/opt -w /opt r-base R CMD INSTALL /opt/Rtwobitlib_0.3.8.1.tar.gz
* installing to library ‘/usr/local/lib/R/site-library’                                                                                                                                                            
* installing *source* package ‘Rtwobitlib’ ...                                                                                                                                                                     
** using staged installation                                                                                                                                                                                       ** libs                     
using C compiler: ‘gcc (Debian 14.2.0-19) 14.2.0’                                                        
cd "kent" && make -f "Makefile.Rtwobitlib"
make[1]: Entering directory '/tmp/Rtmp8Yw4Bj/R.INSTALLa45b6c89b/Rtwobitlib/src/kent'
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I
/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 common.c -o common.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I
/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 localmem.c -o localmem.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I
/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 errAbort.c -o errAbort.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I
/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 hash.c -o hash.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I
/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 bits.c -o bits.o

gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 cheapcgi.c -o cheapcgi.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 linefile.c -o linefile.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 obscure.c -o obscure.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 dnautil.c -o dnautil.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 dnaseq.c -o dnaseq.o
gcc -c -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -fpic -I/usr/share/R/include -I/usr/lib/R/include -D_FILE_OFFSET_BITS=64 twoBit.c -o twoBit.o
ar -rc libtwobit.a common.o localmem.o errAbort.o hash.o bits.o cheapcgi.o linefile.o obscure.o dnautil.o dnaseq.o twoBit.o
ranlib libtwobit.a
## We will need -lcrypto only if we decide to support the
## twoBitOpenExternalBptIndex functionality. See NOTES.txt in this
## folder and Rtwobitlib/inst/unused_but_kept_just_in_case/README.txt
## for more information.
#gcc -shared -Wl,-z,relro -o libtwobit.so common.o localmem.o errAbort.o hash.o bits.o cheapcgi.o linefile.o obscure.o dnautil.o dnaseq.o twoBit.o -lcrypto
gcc -shared -Wl,-z,relro -o libtwobit.so common.o localmem.o errAbort.o hash.o bits.o cheapcgi.o linefile.o obscure.o dnautil.o dnaseq.o twoBit.o
make[1]: Leaving directory '/tmp/Rtmp8Yw4Bj/R.INSTALLa45b6c89b/Rtwobitlib/src/kent'
mkdir -p "/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include/kent"
cd "kent" && cp *.h "/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include/kent"
gcc -I"/usr/share/R/include" -DNDEBUG -D_FILE_OFFSET_BITS=64 -I"/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include"      -fpic  -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -c R_init_Rtwobitlib.c -o R_init_Rtwobitlib.o
gcc -I"/usr/share/R/include" -DNDEBUG -D_FILE_OFFSET_BITS=64 -I"/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include"      -fpic  -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -c Rtwobitlib_utils.c -o Rtwobitlib_utils.o
gcc -I"/usr/share/R/include" -DNDEBUG -D_FILE_OFFSET_BITS=64 -I"/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include"      -fpic  -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -c twobit_roundtrip.c -o twobit_roundtrip.o
gcc -I"/usr/share/R/include" -DNDEBUG -D_FILE_OFFSET_BITS=64 -I"/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/include"      -fpic  -g -O2 -ffile-prefix-map=/build/reproducible-path/r-base-4.4.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -c twobit_seqstats.c -o twobit_seqstats.o
mkdir -p "/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/usrlib"
cd "kent" && cp libtwobit.so libtwobit.a "/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/usrlib"
cd "/usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/usrlib" && ln -s libtwobit.so libtwobit.so.2
gcc -shared -L/usr/lib/R/lib -Wl,-z,relro -o Rtwobitlib.so R_init_Rtwobitlib.o Rtwobitlib_utils.o twobit_roundtrip.o twobit_seqstats.o /usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/usrlib/libtwobit.a -L/usr/lib/R/lib -lR
installing to /usr/local/lib/R/site-library/00LOCK-Rtwobitlib/00new/Rtwobitlib/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (Rtwobitlib)
edd@rob:~/git/rtwobitlib(devel)$ 
```

</details>